### PR TITLE
3ds fix for Blender 2.80

### DIFF
--- a/io_scene_3ds/export_3ds.py
+++ b/io_scene_3ds/export_3ds.py
@@ -1097,6 +1097,11 @@ def save(operator,
     # Make material chunks for all materials used in the meshes:
     for ma_image in materialDict.values():
         object_info.add_subchunk(make_material_chunk(ma_image[0], ma_image[1]))
+    
+    # Added MASTERSCALE element
+    mscale = _3ds_chunk(MASTERSCALE)
+    mscale.add_variable("scale", _3ds_float(1))
+    object_info.add_subchunk(mscale)
 
     # Give all objects a unique ID and build a dictionary from object name to object id:
     """

--- a/io_scene_3ds/export_3ds.py
+++ b/io_scene_3ds/export_3ds.py
@@ -72,9 +72,9 @@ MAT_MAP_UOFFSET = 0xA358  # U axis offset
 MAT_MAP_VOFFSET = 0xA35A  # V axis offset
 MAT_MAP_ANG = 0xA35C      # UV rotation around the z-axis in rad
 
-MATTRANS                = 0xA050  # Transparency value (100-OpacityValue) (percent)
-PCT                     = 0x0030  # Percent chunk
-MASTERSCALE             = 0x0100  # Master scale factor
+MATTRANS = 0xA050  # Transparency value (100-OpacityValue) (percent)
+PCT = 0x0030  # Percent chunk
+MASTERSCALE = 0x0100  # Master scale factor
 
 RGB1 = 0x0011
 RGB2 = 0x0012
@@ -212,9 +212,9 @@ class _3ds_string(object):
         file.write(struct.pack(binary_format, self.value))
 
     def __str__(self):
-        return self.value
+        return str(self.value)
 
-
+    
 class _3ds_point_3d(object):
     """Class representing a three-dimensional point for a 3ds file."""
     __slots__ = "x", "y", "z"
@@ -1029,7 +1029,7 @@ def save(operator,
 
     scene = context.scene
     layer = context.view_layer
-    depsgraph = context.evaluated_depsgraph_get()
+    #depsgraph = context.evaluated_depsgraph_get()
 
     if use_selection:
         objects = (ob for ob in scene.objects if not ob.hide_viewport and ob.select_get(view_layer=layer))
@@ -1047,9 +1047,9 @@ def save(operator,
             if ob.type not in {'MESH', 'CURVE', 'SURFACE', 'FONT', 'META'}:
                 continue
 
-            ob_derived_eval = ob_derived.evaluated_get(depsgraph)
+            #ob_derived_eval = ob_derived.evaluated_get(depsgraph)
             try:
-                data = ob_derived_eval.to_mesh()
+                data = ob_derived.to_mesh()
             except:
                 data = None
 
@@ -1090,7 +1090,7 @@ def save(operator,
                         if f.material_index >= ma_ls_len:
                             f.material_index = 0
 
-                ob_derived_eval.to_mesh_clear()
+                #ob_derived_eval.to_mesh_clear()
 
         if free:
             free_derived_objects(ob)
@@ -1138,8 +1138,8 @@ def save(operator,
         kfdata.add_subchunk(make_kf_obj_node(ob, name_to_id))
         '''
 
-        if not blender_mesh.users:
-            bpy.data.meshes.remove(blender_mesh)
+        #if not blender_mesh.users:
+            #bpy.data.meshes.remove(blender_mesh)
         #blender_mesh.vertices = None
 
         i += i

--- a/io_scene_3ds/export_3ds.py
+++ b/io_scene_3ds/export_3ds.py
@@ -30,6 +30,7 @@ import bpy
 import math
 import struct
 import mathutils
+import bmesh
 
 ######################################################
 # Data Structures
@@ -562,7 +563,7 @@ def make_material_chunk(material, image):
         material_chunk.add_subchunk(make_material_subchunk(MATDIFFUSE, (0.8, 0.8, 0.8)))
         material_chunk.add_subchunk(make_material_subchunk(MATSPECULAR, (1.0, 1.0, 1.0)))
         material_chunk.add_subchunk(make_percent_subchunk(MATSHINESS, .2))
-        material_chunk.add_subchunk(make_percent_subchunk(MATREFLECT, 1))
+        material_chunk.add_subchunk(make_percent_subchunk(MATSHIN2, 1))
         material_chunk.add_subchunk(make_percent_subchunk(MATTRANS, 0))
         
     else:
@@ -570,7 +571,7 @@ def make_material_chunk(material, image):
         material_chunk.add_subchunk(make_material_subchunk(MATDIFFUSE, material.diffuse_color[:3]))
         material_chunk.add_subchunk(make_material_subchunk(MATSPECULAR, material.specular_color[:]))
         material_chunk.add_subchunk(make_percent_subchunk(MATSHINESS, material.specular_intensity))
-        material_chunk.add_subchunk(make_percent_subchunk(MATREFLECT, material.metallic))
+        material_chunk.add_subchunk(make_percent_subchunk(MATSHIN2, material.metallic))
         material_chunk.add_subchunk(make_percent_subchunk(MATTRANS, 1-material.diffuse_color[3]))
         
         slots = get_material_image_texslots(material)  # can be None
@@ -628,8 +629,8 @@ class tri_wrapper(object):
 
 def extract_triangles(mesh):
     """Extract triangles from a mesh.
-
     If the mesh contains quads, they will be split into triangles."""
+    
     tri_list = []
     do_uv = bool(mesh.uv_layers)
 


### PR DESCRIPTION
Fixes:
-  added percent subchunk
-  added specularity and reflection
-  textures from paint slots
-  tesselation to loop triangles
-  material index from polygons
-  fixed matrix multiplication
-  fixed syntax errors
-  mat shortcut renamed to ma
-  moved import modules to the start of the script
-  added alpha data and material property
-  masterscale Element added
-  deactivated evaluated depsgraph
-  fixed 3ds_string output from byte to string

ToDo:
-  restore uv for loop triangles
-  uv texture support
-  fix evaluated depsgraph
-  fix object hierachy



